### PR TITLE
Add a missing `require "set"`

### DIFF
--- a/lib/yarn_lock_parser.rb
+++ b/lib/yarn_lock_parser.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yarn_lock_parser/version"
+require "set"
 
 module YarnLockParser
   class Parser


### PR DESCRIPTION
Set is not always included by default, so make sure it is loaded.
